### PR TITLE
Allow dashes and uppercase chars in gitflow branch names

### DIFF
--- a/functions/__gitnow_functions.fish
+++ b/functions/__gitnow_functions.fish
@@ -15,7 +15,7 @@ end
 
 # adapted from https://gist.github.com/oneohthree/f528c7ae1e701ad990e6
 function __gitnow_slugify
-    echo $argv | command iconv -t ascii//TRANSLIT | command sed -E 's/[^a-zA-Z0-9]+/_/g' | command sed -E 's/^(-|_)+|(-|_)+$//g' | command tr A-Z a-z
+    echo $argv | command iconv -t ascii//TRANSLIT | command sed -E 's/[^a-zA-Z0-9\-]+/_/g' | command sed -E 's/^(-|_)+|(-|_)+$//g'
 end
 
 function __gitnow_clone_repo


### PR DESCRIPTION
I you would like to make the slugify a bit less agressive. I'm trying to follow a standard that accepts "-" and "A-Z" in the feature name

```bash
feature Issue-C123_fix-some-problem
```