### PR TITLE
GPG signed commits support on logs command

### DIFF
--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -355,7 +355,20 @@ function logs -d "Gitnow: Shows logs in a fancy way"
         set args $argv
     end
 
-    command git log $args --color --graph --pretty=format:"%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset" --abbrev-commit | command less -r
+    command git log $args --color --graph \
+        --pretty=format:"%Cred%h%C(reset) -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)%an%C(reset) %C(brightmagenta dim)###%GK###%C(reset)%C(brightblack)@@%G?@@%C(reset)" --abbrev-commit \
+        | command sed -E 's/@@@@//' \
+        | command sed -E 's/@@([^"]*)@@/ (\1)/' \
+        | command sed -E "s/###([^\"]*)###([^\"]*)\(G\)/"(command tput setaf 2)"\1/" \
+        | command sed -E 's/###([^"]*)###/\1/' \
+        | command sed -E 's/\(B\)/(bad signature)/' \
+        | command sed -E 's/\(U\)/(good unknown validity signature)/' \
+        | command sed -E 's/\(X\)/(good expired signature)/' \
+        | command sed -E 's/\(Y\)/(good signature with expired key)/' \
+        | command sed -E 's/\(R\)/(good signature with revoked key)/' \
+        | command sed -E 's/\(E\)/(No checked signature)/' \
+        | command sed -E 's/\(N\)//' \
+        | command less -R
 
     commandline -f repaint
 end


### PR DESCRIPTION
This PR adds support for [GPG signed commits](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work) on `logs` command.

**Screenshot of improved `logs` output.**

![GitNow Logs](https://user-images.githubusercontent.com/1700322/92237891-6ee33a80-eeb8-11ea-812f-0d1160bfab98.png)

For more details about Git logs format check out https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emGem

Additionally it was pipelined a `less -R` for better ANSI "color" sequences displaying.