### PR TITLE
Fix invalid argument error when __gitnow_check_if_branch_exist is used for Fish test checks

### DIFF
--- a/functions/__gitnow_functions.fish
+++ b/functions/__gitnow_functions.fish
@@ -73,10 +73,11 @@ function __gitnow_clone_msg
 end
 
 function __gitnow_check_if_branch_exist
+    set -l xfound 0
+
     if test (count $argv) -eq 1
         set -l xbranch $argv[1]
         set -l xbranch_list (__gitnow_current_branch_list)
-        set -l xfound 0
 
         for b in $xbranch_list
             if [ "$xbranch" = "$b" ]
@@ -84,11 +85,9 @@ function __gitnow_check_if_branch_exist
                 break
             end
         end
-
-        echo $xfound
-    else
-        echo "Provide a valid branch name."
     end
+
+    echo $xfound
 end
 
 function __gitnow_clone_params


### PR DESCRIPTION
This PR fixes an issue when the `__gitnow_check_if_branch_exist` function is used along with the Fish `test` on `if` conditionals. This was occurring because the return type of the function was not consistent.

Here an example of the incoming `merge` command which uses `__gitnow_check_if_branch_exist` function.

```sh
~> merge --continue
# Invalid argument: 'Provide a valid branch name.'
# ~/.config/fish/conf.d/gitnow.fish (line 282):
#    if test $v_found -eq 0
#       ^
# in function 'merge' with arguments '--continue'
# Already up to date.
```