### PR TITLE
fix: Use -q alias when calling fish type command

### DIFF
--- a/functions/__gitnow_config_file.fish
+++ b/functions/__gitnow_config_file.fish
@@ -70,7 +70,7 @@ function __gitnow_read_keybinding_line -d "Reads a keybinding line" -a line
     set -l seq (echo -n $values[2] | LC_ALL=C command tr -d '[:space:]')
 
     # skip out if key is not a valid command
-    if not type --quiet "$cmd"
+    if not type --query "$cmd"
         return
     end
 

--- a/functions/__gitnow_config_file.fish
+++ b/functions/__gitnow_config_file.fish
@@ -70,7 +70,7 @@ function __gitnow_read_keybinding_line -d "Reads a keybinding line" -a line
     set -l seq (echo -n $values[2] | LC_ALL=C command tr -d '[:space:]')
 
     # skip out if key is not a valid command
-    if not type --query "$cmd"
+    if not type -q "$cmd"
         return
     end
 


### PR DESCRIPTION
--quiet is deprecated
See https://github.com/fish-shell/fish-shell/commit/bfb5b28d0f69fe499817d21b1811c3083f76445d