### PR TITLE
Add annotated tags support for `tag` command

### DIFF
--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -495,6 +495,8 @@ function tag -d "Gitnow: Tag commits following Semver"
     set -l v_preminor
     set -l v_prepatch
 
+    set -l opts
+
     # NOTE: this function only gets the latest *Semver release version* but no suffixed ones or others
     set -l v_latest (__gitnow_get_latest_semver_release_tag)
 
@@ -506,6 +508,8 @@ function tag -d "Gitnow: Tag commits following Semver"
                 set v_minor $v
             case -z --patch
                 set v_patch $v
+            case -a --annotate
+                set opts $opts $v
 
             # TODO: pre-release versions are not supported yet
             # case -a --premajor
@@ -537,6 +541,7 @@ function tag -d "Gitnow: Tag commits following Semver"
                 echo "      -y --minor         Tag auto-incrementing a minor version number"
                 echo "      -z --patch         Tag auto-incrementing a patch version number"
                 echo "      -l --latest        Show only the latest Semver release tag version (no suffixed ones or others)"
+                echo "      -a --annotate      Create as annotated tag"
                 echo "      -h --help          Show information about the options for this command"
 
                 # TODO: pre-release versions are not supported yet
@@ -552,7 +557,7 @@ function tag -d "Gitnow: Tag commits following Semver"
     end
 
     # List all tags in a lexicographic order and treating tag names as versions
-    if test -z $argv
+    if test -z $argv[1]
         __gitnow_get_tags_ordered
         return
     end
@@ -560,7 +565,7 @@ function tag -d "Gitnow: Tag commits following Semver"
     # Major version tags
     if test -n "$v_major"
         if not test -n "$v_latest"
-            command git tag v1.0.0
+            command git tag $opts v1.0.0
             echo "First major tag \"v1.0.0\" was created."
             return
         else
@@ -577,7 +582,7 @@ function tag -d "Gitnow: Tag commits following Semver"
             set x (__gitnow_increment_number $x)
             set -l xyz "$prefix$x.0.0"
 
-            command git tag $xyz
+            command git tag $opts $xyz
             echo "Major tag \"$xyz\" was created."
             return
         end
@@ -587,7 +592,7 @@ function tag -d "Gitnow: Tag commits following Semver"
     # Minor version tags
     if test -n "$v_minor"
         if not test -n "$v_latest"
-            command git tag v0.1.0
+            command git tag $opts v0.1.0
             echo "First minor tag \"v0.1.0\" was created."
             return
         else
@@ -605,7 +610,7 @@ function tag -d "Gitnow: Tag commits following Semver"
             set y (__gitnow_increment_number $y)
             set -l xyz "$prefix$x.$y.0"
 
-            command git tag $xyz
+            command git tag $opts $xyz
             echo "Minor tag \"$xyz\" was created."
             return
         end
@@ -615,7 +620,7 @@ function tag -d "Gitnow: Tag commits following Semver"
     # Patch version tags
     if test -n "$v_patch"
         if not test -n "$v_latest"
-            command git tag v0.0.1
+            command git tag $opts v0.0.1
             echo "First patch tag \"v0.1.0\" was created."
             return
         else
@@ -637,7 +642,7 @@ function tag -d "Gitnow: Tag commits following Semver"
                 set s (__gitnow_increment_number $s)
                 set -l xyz "$prefix$x.$y.$s"
 
-                command git tag $xyz
+                command git tag $opts $xyz
                 echo "Patch tag \"$xyz\" was created."
             else
                 echo "No patch version found."

--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -176,12 +176,12 @@ function push -d "Gitnow: Push commit changes to remote repository"
     set -l xorigin (__gitnow_current_remote)
     set -l xbranch (__gitnow_current_branch_name)
 
-    echo "🚀 Pushing changes..."
 
     if test (count $opts) -eq 0
         set opts $xorigin $xbranch
         set -l xremote_url (command git config --get "remote.$xorigin.url")
 
+        echo "🚀 Pushing changes..."
         echo "Mode: Auto"
         echo "Remote URL: $xorigin ($xremote_url)"
         echo "Remote branch: $xbranch"
@@ -194,6 +194,7 @@ function push -d "Gitnow: Push commit changes to remote repository"
                     set opts $xorigin $xbranch --follow-tags
                     set -l xremote_url (command git config --get "remote.$xorigin.url")
 
+                    echo "🚀 Pushing changes..."
                     echo "Mode: Auto (incl. tags)"
                     echo "Remote URL: $xorigin ($xremote_url)"
                     echo "Remote branch: $xbranch"

--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -177,9 +177,11 @@ function push -d "Gitnow: Push commit changes to remote repository"
     set -l xbranch (__gitnow_current_branch_name)
 
     echo "🚀 Pushing changes..."
+
     if test (count $opts) -eq 0
         set opts $xorigin $xbranch
         set -l xremote_url (command git config --get "remote.$xorigin.url")
+
         echo "Mode: Auto"
         echo "Remote URL: $xorigin ($xremote_url)"
         echo "Remote branch: $xbranch"
@@ -213,6 +215,8 @@ function push -d "Gitnow: Push commit changes to remote repository"
     # if test "$v_mode" = "auto";
     #     # Do something
     # end
+
+    echo
 
     command git push --set-upstream $opts
     commandline -f repaint

--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -202,7 +202,7 @@ function push -d "Gitnow: Push commit changes to remote repository"
                     echo "NAME"
                     echo "      Gitnow: push - Push current branch to default origin"
                     echo "OPTIONS:"
-                    echo "      -t --tags               (auto mode) include annotated tags the relate to the commits"
+                    echo "      -t --tags               (auto mode) include annotated tags that relate to the commits"
                     echo "      -h --help               Show information about the options for this command"
                     return
                 case -\*

--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -185,6 +185,13 @@ function push -d "Gitnow: Push commit changes to remote repository"
         echo "Mode: Auto"
         echo "Remote URL: $xorigin ($xremote_url)"
         echo "Remote branch: $xbranch"
+    else if test (count $opts) -eq 1; and [ "$opts[1]" = "--tags" ]
+        set opts $xorigin $xbranch --follow-tags
+        set -l xremote_url (command git config --get "remote.$xorigin.url")
+
+        echo "Mode: Auto (incl. annotated tags in reference to the commits)"
+        echo "Remote URL: $xorigin ($xremote_url)"
+        echo "Remote branch: $xbranch"
     else
         echo "Mode: Manual"
     end

--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -213,10 +213,6 @@ function push -d "Gitnow: Push commit changes to remote repository"
         end
     end
 
-    # if test "$v_mode" = "auto";
-    #     # Do something
-    # end
-
     echo
 
     command git push --set-upstream $opts

--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -177,26 +177,42 @@ function push -d "Gitnow: Push commit changes to remote repository"
     set -l xbranch (__gitnow_current_branch_name)
 
     echo "🚀 Pushing changes..."
-
     if test (count $opts) -eq 0
         set opts $xorigin $xbranch
         set -l xremote_url (command git config --get "remote.$xorigin.url")
-
         echo "Mode: Auto"
         echo "Remote URL: $xorigin ($xremote_url)"
         echo "Remote branch: $xbranch"
-    else if test (count $opts) -eq 1; and [ "$opts[1]" = "--tags" ]
-        set opts $xorigin $xbranch --follow-tags
-        set -l xremote_url (command git config --get "remote.$xorigin.url")
-
-        echo "Mode: Auto (incl. annotated tags in reference to the commits)"
-        echo "Remote URL: $xorigin ($xremote_url)"
-        echo "Remote branch: $xbranch"
     else
-        echo "Mode: Manual"
+        set -l v_mode "auto"
+
+        for v in $argv
+            switch $v
+                case -t --tags
+                    set opts $xorigin $xbranch --follow-tags
+                    set -l xremote_url (command git config --get "remote.$xorigin.url")
+
+                    echo "Mode: Auto (incl. tags)"
+                    echo "Remote URL: $xorigin ($xremote_url)"
+                    echo "Remote branch: $xbranch"
+                case -h --help
+                    echo "NAME"
+                    echo "      Gitnow: push - Push current branch to default origin"
+                    echo "OPTIONS:"
+                    echo "      -t --tags               (auto mode) include annotated tags the relate to the commits"
+                    echo "      -h --help               Show information about the options for this command"
+                    return
+                case -\*
+                case '*'
+                    set -l v_mode "manual"
+                    echo "Mode: Manual"
+            end
+        end
     end
 
-    echo
+    # if test "$v_mode" = "auto";
+    #     # Do something
+    # end
 
     command git push --set-upstream $opts
     commandline -f repaint

--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -557,7 +557,7 @@ function tag -d "Gitnow: Tag commits following Semver"
     end
 
     # List all tags in a lexicographic order and treating tag names as versions
-    if test -z $argv[1]
+    if test -z "$argv"
         __gitnow_get_tags_ordered
         return
     end


### PR DESCRIPTION
Adds the `--annotate` option to create a tag as an annotated one.

Resolves #41 