### PR TITLE
Optional `clipboard` for Gitflow commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ fundle plugin joseluisq/gitnow
 
 **Note:**
 
-- (1) This command key binding will creates a new branch taking as name some text of the clipboard.
+- (1) This command key binding can creates a new branch taking as name some text of the clipboard (optional).
 
 ## Tips
 
@@ -82,10 +82,19 @@ fundle plugin joseluisq/gitnow
 - SSH setup is required for using `github` and `bitbucket` commands.
 - Take advantage of keybindings in order to get faster operations.
 
-## Keybindings configuration
+## Gitnow configuration file
 
-To configure keybindings just copy the [.gitnow](conf.d/.gitnow) file and place it in your home directory (`~/.gitnow`).
-The [.gitnow](conf.d/.gitnow) file contains a _[ keybindings ]_ section with default shortcuts (key-value pairs).
+To configure Gitnow just copy the [.gitnow](conf.d/.gitnow) default file and place it in your home directory (`~/.gitnow`).
+
+### Options
+
+The **_[ options ]_** section contains some options in order to adjust centain Gitnow behaviour.
+
+For more details about the options please take a look at [.gitnow](conf.d/.gitnow) file content.
+
+### Keybindings
+
+The [.gitnow](conf.d/.gitnow) file contains a **_[ keybindings ]_** section with default shortcuts (key-value pairs).
 But you can add, edit or remove keybindings on demand. If you want custom keybindings for your commands just run [fish_key_reader](https://fishshell.com/docs/current/cmds/fish_key_reader.html) in your terminal, then press the key or key's combinations to get the right characters sequence and finally set it to your preferred command in your `~/.gitnow` file.
 
 ## Usage

--- a/conf.d/.gitnow
+++ b/conf.d/.gitnow
@@ -1,3 +1,9 @@
+[ options ]
+
+# Read text from system clipboard or from the standard input
+# only when using Gitflow keybindings
+clipboard = false
+
 [ keybindings ]
 
 # Alt + S

--- a/functions/__gitnow_config_file.fish
+++ b/functions/__gitnow_config_file.fish
@@ -29,32 +29,51 @@ function __gitnow_read_config -d "Reads the GitNow config file"
 
     # Parse `.gitnow` file content
 
+    # 2 = keybindings
+    # 3 = options
     set -l v_section 0
-    set -l v_keybindings_str ""
-    set -l v_keybindings "keybindings"
 
+    # Valid sections
+    set -l v_keybindings "keybindings"
+    set -l v_options "options"
+
+    # Options set 
+    set -l v_clipboard 0
+
+    # Loop every line
     while read -la l
+        set -l v_str ""
         set -l v_comment 0
         set -l v_command_sep 0
         set -l v_command_key ""
         set -l v_command_val ""
 
+        # Loop every char for current line
         echo $l | while read -n 1 -la c;
             switch $c
                 case '['
                     if test $v_comment -eq 1; continue; end
 
-                    if test $v_section -gt 0
-                        set v_section 0
-                        continue
-                    end
+                    # if test $v_section -gt 0
+                    #     set v_section 0
+                    #     continue
+                    # end
 
+                    # Start section
                     if test $v_section -eq 0; set v_section 1; end
                 case ']'
                     if test $v_comment -eq 1; continue; end
 
+                    # Check section name
                     if test $v_section -eq 1
-                        if [ "$v_keybindings_str" = "$v_keybindings" ]
+                        # options
+                        if [ "$v_str" = "$v_options" ]
+                            set v_section 3
+                            continue
+                        end
+                        
+                        # keybindings
+                        if [ "$v_str" = "$v_keybindings" ]
                             set v_section 2
                             continue
                         end
@@ -72,14 +91,15 @@ function __gitnow_read_config -d "Reads the GitNow config file"
                 case '*'
                     if test $v_comment -eq 1; continue; end
 
+                    # If section has started then accumulate chars and continue
                     if test $v_section -eq 1
-                        set v_keybindings_str "$v_keybindings_str$c"
+                        set v_str "$v_str$c"
                         continue
                     end
 
-                    # A [keybindings] section was already found
-                    # NOTE: only alphabetic chars and hyphens are supported
-                    if test $v_section -eq 2
+                    # A [ abcde ] section is found so proceed with chars handling 
+                    # NOTE: only alphabetic and hyphens chars are allowed
+                    if test $v_section -eq 2; or test $v_section -eq 3
                         switch $c
                             case 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 'u' 'v' 'w' 'x' 'y' 'z' '-'
                                 if test $v_command_sep -eq 0
@@ -98,6 +118,10 @@ function __gitnow_read_config -d "Reads the GitNow config file"
                                 continue
                             case '='
                                 set v_command_sep 1
+                                if test $v_section -eq 3
+                                    set v_command_sep 2
+                                    continue
+                                end
                             case '*'
                                 continue
                         end
@@ -105,14 +129,37 @@ function __gitnow_read_config -d "Reads the GitNow config file"
             end
         end
 
+        # 1. Handle options set
+        if test $v_section -eq 3
+            switch $v_command_key
+                # Clipboard option
+                case 'clipboard'
+                    if [ "$v_command_val" = "true" ]
+                        set v_clipboard 1
+                    end
+                # NOTE: handle future new options using a new case
+                case '*'
+                    continue
+            end
+            # continue loop after current option processed
+            set v_section 0
+            continue
+        end
+
+        # 2. Handle keybindings set
         if not [ "$v_command_key" = "" ]; and not [ "$v_command_val" = "" ]
             set -l cmd
 
             switch $v_command_key
                 case 'release' 'hotfix' 'feature' 'bugfix'
-                    # Skip out if there is no a valid clipboard program
-
-                    set cmd (echo -n "bind \\$v_command_val \"echo; if $v_command_key (__gitnow_get_user_input); commandline -f repaint; else ; end\"")
+                    # Read text from clipboard if there is a valid clipboard program
+                    # and if the "clipboard" option is "true"
+                    if test -n $gitnow_xpaste; and test $v_clipboard -eq 1
+                        set cmd (echo -n "bind \\$v_command_val \"echo; if $v_command_key ($gitnow_xpaste); commandline -f repaint; else ; end\"")
+                    else
+                        # Otherwise read text from standard input
+                        set cmd (echo -n "bind \\$v_command_val \"echo; if $v_command_key (read); commandline -f repaint; else ; end\"")
+                    end
                 case '*'
                     # Check command key against a list of valid commands
                     set -l v_valid 0
@@ -149,19 +196,4 @@ function __gitnow_get_clip_program -d "Gets the current clip installed program"
     end
 
     echo -n $v_paste
-end
-
-function __gitnow_get_user_input -d "Read for branch name"
-    echo -n (__gitnow_slugify (read))
-end
-
-function __gitnow_slugify -d "Slugify string"
-    set -l v_read
-    set v_read (echo -n $argv | iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9-]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)
-
-    if test $status = 0
-        echo -n $v_read
-    else
-        echo "Can't slugify given string \\$argv"
-    end
 end

--- a/functions/__gitnow_config_file.fish
+++ b/functions/__gitnow_config_file.fish
@@ -111,9 +111,8 @@ function __gitnow_read_config -d "Reads the GitNow config file"
             switch $v_command_key
                 case 'release' 'hotfix' 'feature' 'bugfix'
                     # Skip out if there is no a valid clipboard program
-                    if not test -n $gitnow_xpaste; continue; end
 
-                    set cmd (echo -n "bind \\$v_command_val \"echo; if $v_command_key ($gitnow_xpaste); commandline -f repaint; else ; end\"")
+                    set cmd (echo -n "bind \\$v_command_val \"echo; if $v_command_key (__gitnow_get_user_input); commandline -f repaint; else ; end\"")
                 case '*'
                     # Check command key against a list of valid commands
                     set -l v_valid 0
@@ -150,4 +149,19 @@ function __gitnow_get_clip_program -d "Gets the current clip installed program"
     end
 
     echo -n $v_paste
+end
+
+function __gitnow_get_user_input -d "Read for branch name"
+    echo -n (__gitnow_slugify (read))
+end
+
+function __gitnow_slugify -d "Slugify string"
+    set -l v_read
+    set v_read (echo -n $argv | iconv -t ascii//TRANSLIT | sed -E 's/[^a-zA-Z0-9-]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)
+
+    if test $status = 0
+        echo -n $v_read
+    else
+        echo "Can't slugify given string \\$argv"
+    end
 end


### PR DESCRIPTION
I really like the Hotkey shortcuts to create feature/hotfix/bugfix branches, but i think using the clipboard is rather inconvenient.
This is a really amature idea for reading the user input to set the branch name including a slugify method.

There could be a setting to enable either clipboard / read input and another setting to enable automaticly slugifying given names.
I tried to add those settings myself within the .gitnow config file but didn't really understand how the parsing works and have given up.