### PR TITLE
refactor: adding commit-all to gitnow_commands

### DIFF
--- a/functions/__gitnow_config_file.fish
+++ b/functions/__gitnow_config_file.fish
@@ -3,7 +3,7 @@
 
 set -g gitnow_xpaste
 
-set -g gitnow_commands 'all' 'assume' 'bitbucket' 'bugfix' 'commit' 'feature' 'github' 'gitnow' 'hotfix' 'logs' 'merge' 'move' 'pull' 'push' 'release' 'show' 'stage' 'state' 'tag' 'unstage' 'untracked' 'upstream'
+set -g gitnow_commands 'all' 'assume' 'bitbucket' 'bugfix' 'commit' 'commit-all' 'feature' 'github' 'gitnow' 'hotfix' 'logs' 'merge' 'move' 'pull' 'push' 'release' 'show' 'stage' 'state' 'tag' 'unstage' 'untracked' 'upstream'
 
 function __gitnow_read_config -d "Reads the GitNow config file"
     # Sets a clipboard program


### PR DESCRIPTION
With default install, commit-all is not registered.

I couldn't use Alt+c prior adding it in gitnow_commands.