### PR TITLE
Previous branch switching support for `move` command

### DIFF
--- a/completions/__gitnow_completions.fish
+++ b/completions/__gitnow_completions.fish
@@ -25,6 +25,10 @@ complete -f -x -c move \
     -d "Show information about the options for this command"
 
 complete -f -x -c move \
+    -s p -l prev \
+    -d "Switch to a previous branch using the `--no-apply-stash` option (equivalent to \"move -\")"
+
+complete -f -x -c move \
     -s n -l no-apply-stash \
     -a '(__fish_git_branches)' \
     -d "Switch to a local branch but without applying current stash"


### PR DESCRIPTION
This PR adds previous branch switching support to the `move` command.

**Shorthand variant:**

```fish
move -
```

**Option variants:**

```fish
move -p
# or
move --prev
```

**Notes**

- Previous branch switching only works via the `move` command. E.g if you switched to a branch using `git checkout ...` manually, then `move -` will lose track of the previous branch.
- When switching `move` uses the `--no-apply-stash` option by default.

More details via `move -h`

It resolves #35