### PR TITLE
feat: Enable Fish's `git <command>` completion on simple wrappers

### DIFF
--- a/conf.d/gitnow.fish
+++ b/conf.d/gitnow.fish
@@ -30,7 +30,7 @@ function state -d "Gitnow: Show the working tree status in compact way"
     command git status -sb
 end
 
-function stage -d "Gitnow: Stage files in current working directory"
+function stage -d "Gitnow: Stage files in current working directory" -w 'git add'
     if not __gitnow_is_git_repository
         __gitnow_msg_not_valid_repository "stage"
         return
@@ -46,7 +46,7 @@ function stage -d "Gitnow: Stage files in current working directory"
     command git add $opts
 end
 
-function unstage -d "Gitnow: Unstage files in current working directory"
+function unstage -d "Gitnow: Unstage files in current working directory" -w 'git reset'
     if not __gitnow_is_git_repository
         __gitnow_msg_not_valid_repository "unstage"
         return
@@ -62,7 +62,7 @@ function unstage -d "Gitnow: Unstage files in current working directory"
     command git reset $opts
 end
 
-function show -d "Gitnow: Show commit detail objects"
+function show -d "Gitnow: Show commit detail objects" -w 'git show'
     if not __gitnow_is_git_repository
         __gitnow_msg_not_valid_repository "show"
         return
@@ -87,7 +87,7 @@ function untracked -d "Gitnow: Check for untracked files and directories on curr
 
 end
 
-function commit -d "Gitnow: Commit changes to the repository"
+function commit -d "Gitnow: Commit changes to the repository" -w 'git commit'
     if not __gitnow_is_git_repository
         __gitnow_msg_not_valid_repository "commit"
         return
@@ -112,7 +112,7 @@ function commit-all -d "Gitnow: Add and commit all changes to the repository"
     commit .
 end
 
-function pull -d "Gitnow: Pull changes from remote server but stashing uncommitted changes"
+function pull -d "Gitnow: Pull changes from remote server but stashing uncommitted changes" -w 'git pull'
     if not __gitnow_is_git_repository
         __gitnow_msg_not_valid_repository "pull"
         return
@@ -159,7 +159,7 @@ end
 
 # Git push with --set-upstream
 # Shortcut inspired from https://github.com/jamiew/git-friendly
-function push -d "Gitnow: Push commit changes to remote repository"
+function push -d "Gitnow: Push commit changes to remote repository" -w 'git push'
     if not __gitnow_is_git_repository
         __gitnow_msg_not_valid_repository "push"
         return
@@ -373,7 +373,7 @@ function move -d "GitNow: Switch from current branch to another but stashing unc
         end
     end
 
-    # Move to prev branch either via the --prev option or the "-" shorthand char 
+    # Move to prev branch either via the --prev option or the "-" shorthand char
     if begin test -n "$v_prev"; or [ "$args" = "-" ]; end
         if begin test -z "$g_current_branch"; or [ "$g_current_branch" = (__gitnow_current_branch_name) ]; end
             echo "Previous branch not found or the same as current one. Nothing to do."


### PR DESCRIPTION
**Goal:** This patch aims to bring Fish's awesome completion to everyday git wrappers that pass `$argv` to the command they call.

**Motivation:** I love this plugin and it's part of the first few things I always put on all of my fresh Linux installs, but it has always bugged me how it doesn't provide users with `git <command>` completions on some shorthands that I use daily and accept any of `<command>`'s flags/options. Fish's `function` directive has an option to specify that it's a wrapper, I figured it was only some of Gitnow's wrappers make use of it.

**Affected commands:**
  - `stage` -> wraps `git add`
  - `unstage` -> wraps `git reset`
  - `show` -> wraps `git show`
  - `commit` -> wraps `git commit`
  - `push` -> wraps `git push`
  - `pull` -> wraps `git pull`

Have a good day, and thanks for the excellent workflow QOL you've provided me and  many users with!

 PS: Seems my automatic whitespace cleanup found a trailing space at line 376... Oh well. ¯\\\_(ツ)_/¯