### PR TITLE
Custom remote branch path support `-r, --remote-branch` option for `move` command

### DIFF
--- a/completions/move.fish
+++ b/completions/move.fish
@@ -24,3 +24,9 @@ complete -f -x -c move \
     -s u -l upstream \
     -a '(__fish_git_branches)' \
     -d "Fetch a remote branch and switch to it applying current stash"
+
+complete -f -x -c move \
+    -s r -l remote-branch \
+    -n 'contains -- -u (commandline -opc); or contains -- --upstream (commandline -opc)' \
+    -a '(__fish_git_branches)' \
+    -d "Use a custom remote branch path like '<origin>/<master>' when wanting to switch."


### PR DESCRIPTION
This PR adds support for using a custom remote branch path like `<origin>/<master>` when wanting to switch to a specific remote branch. It makes it easier to switch between multiple remote branches apart from the current one (e.g., `origin`). 

The `-r, --remote-branch` option requires the `-u, --upstream` to be provided together.

```sh
move -h
#      -r --remote-branch      Use a custom remote branch path like '<origin>/<master>' when wanting to switch. It requires the '-u, --upstream' option.
```

**Examples**

For switching to specific remote branches (not only on the current one), use these variants:

```fish
# Using it with `-u, --upstream`
move --upstream --remote-branch my-remote/my-branch
move -u -r my-remote/some/branch
move -ur my-remote/my-branch

# Using it with `-n, --no-apply-stash`
move -nur my-remote/my-branch
move -unr my-remote/some/branch
```

For switching to remote branches on the current remote only (e.g., `origin`), use these variants:

```fish
move --upstream my-branch
move -u my-branch
```