### PR TITLE
Keep local branch list order in completions for certain commands like `move`, `merge` and `tag` 

### DIFF
--- a/completions/merge.fish
+++ b/completions/merge.fish
@@ -5,7 +5,7 @@
 
 __gitnow_load_git_functions
 
-complete -f -x -c merge -a '(__fish_git_branches)'
+complete -f -k -x -c merge -a '(__fish_git_branches)'
 
 complete -f -x -c merge \
     -s h -l help \

--- a/completions/move.fish
+++ b/completions/move.fish
@@ -5,9 +5,9 @@
 
 __gitnow_load_git_functions
 
-complete -f -x -c move -a '(__fish_git_branches)'
+complete -f -k -x -c move -a '(__fish_git_branches)'
 
-complete -f -x -c move \
+complete -f -k -x -c move \
     -s h -l help \
     -d "Show information about the options for this command"
 
@@ -15,17 +15,17 @@ complete -f -x -c move \
     -s p -l prev \
     -d "Switch to a previous branch using the `--no-apply-stash` option (equivalent to \"move -\")"
 
-complete -f -x -c move \
+complete -f -k -x -c move \
     -s n -l no-apply-stash \
     -a '(__fish_git_branches)' \
     -d "Switch to a local branch but without applying current stash"
 
-complete -f -x -c move \
+complete -f -k -x -c move \
     -s u -l upstream \
     -a '(__fish_git_branches)' \
     -d "Fetch a remote branch and switch to it applying current stash"
 
-complete -f -x -c move \
+complete -f -k -x -c move \
     -s r -l remote-branch \
     -n 'contains -- -u (commandline -opc); or contains -- --upstream (commandline -opc)' \
     -a '(__fish_git_branches)' \

--- a/completions/tag.fish
+++ b/completions/tag.fish
@@ -5,10 +5,10 @@
 
 __gitnow_load_git_functions
 
-complete -f -x -c tag \
+complete -f -k -x -c tag \
     -d "List all tags in a lexicographic order and treating tag names as versions"
 
-complete -f -x -c tag -a '(__fish_git_tags)'
+complete -f -k -x -c tag -a '(__fish_git_tags)'
 
 complete -f -x -c tag \
     -s h -l help \


### PR DESCRIPTION
This MR prevents the default **local** branch list sorting (_alphabetical order_) in **completions** (current behaviour) and preserves git branch sorting by **recency** instead (via `__fish_git_branches`).

Those changes will help navigate to _latest committed branches_ quickly in completions when using either `move`, `merge` or `tag` commands. In particular, when having many local branches.
See Fish shell [`complete`](https://fishshell.com/docs/current/cmds/complete.html) command for more details.

Commands affected:

- `merge`
- `move`
- `tag`